### PR TITLE
Set up cross-compilation, add Linux targets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
@@ -28,61 +28,80 @@ jobs:
             exit 1
           fi
 
-  build-mac:
-    name: Mac executable
-    runs-on: macos-latest
-    needs: changelog
-    steps:
-      - uses: actions/checkout@v3
-      - uses: dtolnay/rust-toolchain@stable
-      - run: cargo build --release --all-features
-      - run: cargo test
-      - name: 'Upload Artifact'
-        uses: actions/upload-artifact@v2
-        with:
-          name: directory-packages-props-converter-mac
-          path: target/release/directory-packages-props-converter
+  build:
+    name: Build - ${{ matrix.platform.release_for }}
+    strategy:
+      matrix:
+        platform:
+          - release_for: linux-amd64
+            os: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+            bin: directory-packages-props-converter
+            name: directory-packages-props-converter-linux-amd64
+            command: build
 
-  build-windows:
-    name: Windows executable
-    runs-on: windows-latest
-    needs: changelog
+          - release_for: linux-arm64
+            os: ubuntu-latest
+            target: aarch64-unknown-linux-gnu
+            bin: directory-packages-props-converter
+            name: directory-packages-props-converter-linux-arm64
+
+          - release_for: macos-amd64
+            os: macos-latest
+            target: x86_64-apple-darwin
+            bin: directory-packages-props-converter
+            name: directory-packages-props-converter-macos-amd64
+
+          - release_for: macos-arm64
+            os: macos-latest
+            target: aarch64-apple-darwin
+            bin: directory-packages-props-converter
+            name: directory-packages-props-converter-macos-arm64
+
+          - release_for: windows-amd64
+            os: windows-latest
+            target: x86_64-pc-windows-msvc
+            bin: directory-packages-props-converter.exe
+            name: directory-packages-props-converter-windows-amd64.exe
+
+    runs-on: ${{ matrix.platform.os }}
     steps:
-      - uses: actions/checkout@v3
-      - uses: dtolnay/rust-toolchain@stable
-      - run: cargo build --release --all-features
-      - run: cargo test
-      - name: 'Upload Artifact'
-        uses: actions/upload-artifact@v2
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Build binary
+        uses: houseabsolute/actions-rust-cross@v0
         with:
-          name: directory-packages-props-converter-win.exe
-          path: target/release/directory-packages-props-converter.exe
+          command: build
+          target: ${{ matrix.platform.target }}
+          args: "--locked --release"
+          strip: true
+      - run: mv target/${{ matrix.platform.target }}/release/${{ matrix.platform.bin }} ${{ matrix.platform.name }}
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.platform.name }}
+          path: ${{ matrix.platform.name }}
 
   release:
     permissions: write-all
     name: Release
     runs-on: ubuntu-latest
-    needs: [build-mac, build-windows]
+    needs: build
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      
+
       - name: Get version from CHANGELOG.md
         id: changelog_reader
         uses: mindsers/changelog-reader-action@v2
         with:
           path: ./CHANGELOG.md
 
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
-          name: directory-packages-props-converter-mac
-          path: .
-
-      - uses: actions/download-artifact@v3
-        with:
-          name: directory-packages-props-converter-win.exe
-          path: .
+          path: dist
+          merge-multiple: true
 
       - name: Push a tag
         id: push_tag
@@ -93,12 +112,11 @@ jobs:
           release_branches: master
 
       - name: Release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2
         with:
           body: ${{ steps.changelog_reader.outputs.changes }}
           tag_name: v${{ steps.changelog_reader.outputs.version }}
           name: ${{ steps.changelog_reader.outputs.version }}
           files: |
-            directory-packages-props-converter.exe
-            directory-packages-props-converter
+            dist/**
             LICENSE

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
+## [0.3.1] - 2024-03-15
+* Added Linux versions of the released binaries.
+
 ## [0.3.0] - 2023-10-20
 * Updating the `<PackageReference>` is more tolerant towards additional whitespace
 


### PR DESCRIPTION
This tweaks the CI script to target Linux (amd64 and arm64) and macOS amd64. It also consolidates the steps that were referencing specific build targets, making it easier to target another platform in the future by simply adding a new block to the build step matrix.

Example results:

[Workflow run](https://github.com/justin-sleep/directory-packages-props-converter/actions/runs/8299071022)

[Release](https://github.com/justin-sleep/directory-packages-props-converter/releases/tag/v0.3.1)